### PR TITLE
Fixups for a few format-security compile-time warnings

### DIFF
--- a/cm/CollisionModel_debug.cpp
+++ b/cm/CollisionModel_debug.cpp
@@ -137,7 +137,7 @@ const char *idCollisionModelManagerLocal::StringFromContents( const int contents
 			if ( length != 0 ) {
 				length += idStr::snPrintf( contentsString + length, sizeof( contentsString ) - length, "," );
 			}
-			length += idStr::snPrintf( contentsString + length, sizeof( contentsString ) - length, cm_contentsNameByIndex[i] );
+			length += idStr::snPrintf( contentsString + length, sizeof( contentsString ) - length, "%s", cm_contentsNameByIndex[i] );
 		}
 	}
 

--- a/d3xp/Game_local.cpp
+++ b/d3xp/Game_local.cpp
@@ -1526,7 +1526,7 @@ bool idGameLocal::NextMap( void ) {
 	int					i;
 
 	if ( !g_mapCycle.GetString()[0] ) {
-		Printf( common->GetLanguageDict()->GetString( "#str_04294" ) );
+		Printf( "%s", common->GetLanguageDict()->GetString( "#str_04294" ) );
 		return false;
 	}
 	if ( fileSystem->ReadFile( g_mapCycle.GetString(), NULL, NULL ) < 0 ) {

--- a/d3xp/Game_network.cpp
+++ b/d3xp/Game_network.cpp
@@ -728,7 +728,7 @@ void idGameLocal::NetworkEventWarning( const entityNetEvent_t *event, const char
 	va_end( argptr );
 	idStr::Append( buf, sizeof(buf), "\n" );
 
-	common->DWarning( buf );
+	common->DWarning( "%s", buf );
 }
 
 /*

--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -2915,7 +2915,7 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 					AddChatLine( common->GetLanguageDict()->GetString( "#str_11121" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 				}
 			} else {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11105" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );                       
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11105" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
 			}
 			break;
 

--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -2823,23 +2823,23 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 	switch ( evt ) {
 		case MSG_SUICIDE:
 			assert( parm1 >= 0 );
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04293" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04293" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_KILLED:
 			assert( parm1 >= 0 && parm2 >= 0 );
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04292" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04292" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
 			break;
 		case MSG_KILLEDTEAM:
 			assert( parm1 >= 0 && parm2 >= 0 );
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04291" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04291" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
 			break;
 		case MSG_TELEFRAGGED:
 			assert( parm1 >= 0 && parm2 >= 0 );
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04290" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04290" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
 			break;
 		case MSG_DIED:
 			assert( parm1 >= 0 );
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04289" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04289" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_VOTE:
 			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04288" ) );
@@ -2848,35 +2848,35 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04287" ) );
 			break;
 		case MSG_FORCEREADY:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04286" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04286" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			if ( gameLocal.entities[ parm1 ] && gameLocal.entities[ parm1 ]->IsType( idPlayer::Type ) ) {
 				static_cast< idPlayer * >( gameLocal.entities[ parm1 ] )->forcedReady = true;
 			}
 			break;
 		case MSG_JOINEDSPEC:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04285" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04285" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_TIMELIMIT:
 			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04284" ) );
 			break;
 		case MSG_FRAGLIMIT:
 			if ( gameLocal.gameType == GAME_LASTMAN ) {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04283" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_04283" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			} else if ( IsGametypeTeamBased() ) { /* CTF */
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04282" ), gameLocal.userInfo[ parm1 ].GetString( "ui_team" ) );
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_04282" ), gameLocal.userInfo[ parm1 ].GetString( "ui_team" ) );
 			} else {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04281" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_04281" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			}
 			break;
 		case MSG_JOINTEAM:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04280" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), parm2 ? common->GetLanguageDict()->GetString( "#str_02500" ) : common->GetLanguageDict()->GetString( "#str_02499" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04280" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), parm2 ? common->GetLanguageDict()->GetString( "#str_02500" ) : common->GetLanguageDict()->GetString( "#str_02499" ) );
 			break;
 		case MSG_HOLYSHIT:
 			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_06732" ) );
 			break;
 #ifdef CTF
 		case MSG_POINTLIMIT:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11100" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111"  ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_11100" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111"  ) );
 			break;
 
 		case MSG_FLAGTAKEN :
@@ -2887,9 +2887,9 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 				break;
 
 			if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11101" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11101" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
 			} else {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11102" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11102" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 			}
 			break;
 
@@ -2910,12 +2910,12 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 
 			if ( parm2 >= 0 && parm2 < MAX_CLIENTS ) {
 				if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-					AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11120" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
+					AddChatLine( common->GetLanguageDict()->GetString( "#str_11120" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
 				} else {
-					AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11121" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
+					AddChatLine( common->GetLanguageDict()->GetString( "#str_11121" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 				}
 			} else {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11105" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11105" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );                       
 			}
 			break;
 
@@ -2927,16 +2927,16 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 				break;
 
 			if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11122" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11122" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
 			} else {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11123" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11123" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 			}	
 			
-//			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11106" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
+//			AddChatLine( common->GetLanguageDict()->GetString( "#str_11106" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
 			break;
 
 		case MSG_SCOREUPDATE:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11107" ), parm1, parm2 );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_11107" ), parm1, parm2 );
 			break;
 #endif
 		default:
@@ -3257,7 +3257,7 @@ void idMultiplayerGame::ClientStartVote( int clientNum, const char *_voteString 
 	}
 
 	voteString = _voteString;
-	AddChatLine( "%s", va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
+	AddChatLine( va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
 	gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE ] );
 	if ( clientNum == gameLocal.localClientNum ) {
 		voted = true;
@@ -3905,7 +3905,7 @@ void idMultiplayerGame::ThrottleUserInfo( void ) {
 		if ( idStr::Icmp( gameLocal.userInfo[ gameLocal.localClientNum ].GetString( ThrottleVars[ i ] ),
 			cvarSystem->GetCVarString( ThrottleVars[ i ] ) ) ) {
 			if ( gameLocal.realClientTime < switchThrottle[ i ] ) {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04299" ), common->GetLanguageDict()->GetString( ThrottleVarsInEnglish[ i ] ), ( switchThrottle[ i ] - gameLocal.time ) / 1000 + 1 );
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_04299" ), common->GetLanguageDict()->GetString( ThrottleVarsInEnglish[ i ] ), ( switchThrottle[ i ] - gameLocal.time ) / 1000 + 1 );
 				cvarSystem->SetCVarString( ThrottleVars[ i ], gameLocal.userInfo[ gameLocal.localClientNum ].GetString( ThrottleVars[ i ] ) );
 			} else {
 				switchThrottle[ i ] = gameLocal.time + ThrottleDelay[ i ] * 1000;

--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -3257,7 +3257,7 @@ void idMultiplayerGame::ClientStartVote( int clientNum, const char *_voteString 
 	}
 
 	voteString = _voteString;
-	AddChatLine( "%s", va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
+	AddChatLine( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) );
 	gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE ] );
 	if ( clientNum == gameLocal.localClientNum ) {
 		voted = true;

--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -3257,7 +3257,7 @@ void idMultiplayerGame::ClientStartVote( int clientNum, const char *_voteString 
 	}
 
 	voteString = _voteString;
-	AddChatLine( va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
+	AddChatLine( "%s", va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
 	gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE ] );
 	if ( clientNum == gameLocal.localClientNum ) {
 		voted = true;

--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -2842,10 +2842,10 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 			AddChatLine( common->GetLanguageDict()->GetString( "#str_04289" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_VOTE:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04288" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04288" ) );
 			break;
 		case MSG_SUDDENDEATH:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04287" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04287" ) );
 			break;
 		case MSG_FORCEREADY:
 			AddChatLine( common->GetLanguageDict()->GetString( "#str_04286" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
@@ -2857,7 +2857,7 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 			AddChatLine( common->GetLanguageDict()->GetString( "#str_04285" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_TIMELIMIT:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04284" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04284" ) );
 			break;
 		case MSG_FRAGLIMIT:
 			if ( gameLocal.gameType == GAME_LASTMAN ) {
@@ -2872,7 +2872,7 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 			AddChatLine( common->GetLanguageDict()->GetString( "#str_04280" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), parm2 ? common->GetLanguageDict()->GetString( "#str_02500" ) : common->GetLanguageDict()->GetString( "#str_02499" ) );
 			break;
 		case MSG_HOLYSHIT:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_06732" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_06732" ) );
 			break;
 #ifdef CTF
 		case MSG_POINTLIMIT:
@@ -2898,9 +2898,9 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
                 break;
 
 			if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11103" ) );	// your team
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11103" ) );	// your team
 			} else {
-				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11104" ) );	// enemy
+				AddChatLine( common->GetLanguageDict()->GetString( "#str_11104" ) );	// enemy
 			}
 			break;
 
@@ -3297,14 +3297,14 @@ void idMultiplayerGame::ClientUpdateVote( vote_result_t status, int yesCount, in
 
 	switch ( status ) {
 		case VOTE_FAILED:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04278" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04278" ) );
 			gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE_FAILED ] );
 			if ( gameLocal.isClient ) {
 				vote = VOTE_NONE;
 			}
 			break;
 		case VOTE_PASSED:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04277" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04277" ) );
 			gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE_PASSED ] );
 			break;
 		case VOTE_RESET:
@@ -3313,7 +3313,7 @@ void idMultiplayerGame::ClientUpdateVote( vote_result_t status, int yesCount, in
 			}
 			break;
 		case VOTE_ABORTED:
-			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04276" ) );
+			AddChatLine( common->GetLanguageDict()->GetString( "#str_04276" ) );
 			if ( gameLocal.isClient ) {
 				vote = VOTE_NONE;
 			}
@@ -3851,7 +3851,7 @@ void idMultiplayerGame::ToggleSpectate( void ) {
 		if ( gameLocal.serverInfo.GetBool( "si_spectators" ) ) {
 			cvarSystem->SetCVarString( "ui_spectate", "Spectate" );
 		} else {
-			gameLocal.mpGame.AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_06747" ) );
+			gameLocal.mpGame.AddChatLine( common->GetLanguageDict()->GetString( "#str_06747" ) );
 		}
 	}
 }

--- a/d3xp/MultiplayerGame.cpp
+++ b/d3xp/MultiplayerGame.cpp
@@ -2823,60 +2823,60 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 	switch ( evt ) {
 		case MSG_SUICIDE:
 			assert( parm1 >= 0 );
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04293" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04293" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_KILLED:
 			assert( parm1 >= 0 && parm2 >= 0 );
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04292" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04292" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
 			break;
 		case MSG_KILLEDTEAM:
 			assert( parm1 >= 0 && parm2 >= 0 );
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04291" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04291" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
 			break;
 		case MSG_TELEFRAGGED:
 			assert( parm1 >= 0 && parm2 >= 0 );
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04290" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04290" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );
 			break;
 		case MSG_DIED:
 			assert( parm1 >= 0 );
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04289" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04289" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_VOTE:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04288" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04288" ) );
 			break;
 		case MSG_SUDDENDEATH:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04287" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04287" ) );
 			break;
 		case MSG_FORCEREADY:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04286" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04286" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			if ( gameLocal.entities[ parm1 ] && gameLocal.entities[ parm1 ]->IsType( idPlayer::Type ) ) {
 				static_cast< idPlayer * >( gameLocal.entities[ parm1 ] )->forcedReady = true;
 			}
 			break;
 		case MSG_JOINEDSPEC:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04285" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04285" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			break;
 		case MSG_TIMELIMIT:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04284" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04284" ) );
 			break;
 		case MSG_FRAGLIMIT:
 			if ( gameLocal.gameType == GAME_LASTMAN ) {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_04283" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04283" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			} else if ( IsGametypeTeamBased() ) { /* CTF */
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_04282" ), gameLocal.userInfo[ parm1 ].GetString( "ui_team" ) );
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04282" ), gameLocal.userInfo[ parm1 ].GetString( "ui_team" ) );
 			} else {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_04281" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04281" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ) );
 			}
 			break;
 		case MSG_JOINTEAM:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04280" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), parm2 ? common->GetLanguageDict()->GetString( "#str_02500" ) : common->GetLanguageDict()->GetString( "#str_02499" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04280" ), gameLocal.userInfo[ parm1 ].GetString( "ui_name" ), parm2 ? common->GetLanguageDict()->GetString( "#str_02500" ) : common->GetLanguageDict()->GetString( "#str_02499" ) );
 			break;
 		case MSG_HOLYSHIT:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_06732" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_06732" ) );
 			break;
 #ifdef CTF
 		case MSG_POINTLIMIT:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_11100" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111"  ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11100" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111"  ) );
 			break;
 
 		case MSG_FLAGTAKEN :
@@ -2887,9 +2887,9 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 				break;
 
 			if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11101" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11101" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
 			} else {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11102" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11102" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 			}
 			break;
 
@@ -2898,9 +2898,9 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
                 break;
 
 			if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11103" ) );	// your team
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11103" ) );	// your team
 			} else {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11104" ) );	// enemy
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11104" ) );	// enemy
 			}
 			break;
 
@@ -2910,12 +2910,12 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 
 			if ( parm2 >= 0 && parm2 < MAX_CLIENTS ) {
 				if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-					AddChatLine( common->GetLanguageDict()->GetString( "#str_11120" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
+					AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11120" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
 				} else {
-					AddChatLine( common->GetLanguageDict()->GetString( "#str_11121" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
+					AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11121" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 				}
 			} else {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11105" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );                       
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11105" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
 			}
 			break;
 
@@ -2927,16 +2927,16 @@ void idMultiplayerGame::PrintMessageEvent( int to, msg_evt_t evt, int parm1, int
 				break;
 
 			if ( gameLocal.GetLocalPlayer()->team != parm1 ) {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11122" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11122" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// your team
 			} else {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_11123" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11123" ), gameLocal.userInfo[ parm2 ].GetString( "ui_name" ) );	// enemy
 			}	
 			
-//			AddChatLine( common->GetLanguageDict()->GetString( "#str_11106" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
+//			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11106" ), parm1 ? common->GetLanguageDict()->GetString( "#str_11110" ) : common->GetLanguageDict()->GetString( "#str_11111" ) );
 			break;
 
 		case MSG_SCOREUPDATE:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_11107" ), parm1, parm2 );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_11107" ), parm1, parm2 );
 			break;
 #endif
 		default:
@@ -3257,7 +3257,7 @@ void idMultiplayerGame::ClientStartVote( int clientNum, const char *_voteString 
 	}
 
 	voteString = _voteString;
-	AddChatLine( va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
+	AddChatLine( "%s", va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
 	gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE ] );
 	if ( clientNum == gameLocal.localClientNum ) {
 		voted = true;
@@ -3297,14 +3297,14 @@ void idMultiplayerGame::ClientUpdateVote( vote_result_t status, int yesCount, in
 
 	switch ( status ) {
 		case VOTE_FAILED:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04278" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04278" ) );
 			gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE_FAILED ] );
 			if ( gameLocal.isClient ) {
 				vote = VOTE_NONE;
 			}
 			break;
 		case VOTE_PASSED:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04277" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04277" ) );
 			gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE_PASSED ] );
 			break;
 		case VOTE_RESET:
@@ -3313,7 +3313,7 @@ void idMultiplayerGame::ClientUpdateVote( vote_result_t status, int yesCount, in
 			}
 			break;
 		case VOTE_ABORTED:
-			AddChatLine( common->GetLanguageDict()->GetString( "#str_04276" ) );
+			AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04276" ) );
 			if ( gameLocal.isClient ) {
 				vote = VOTE_NONE;
 			}
@@ -3851,7 +3851,7 @@ void idMultiplayerGame::ToggleSpectate( void ) {
 		if ( gameLocal.serverInfo.GetBool( "si_spectators" ) ) {
 			cvarSystem->SetCVarString( "ui_spectate", "Spectate" );
 		} else {
-			gameLocal.mpGame.AddChatLine( common->GetLanguageDict()->GetString( "#str_06747" ) );
+			gameLocal.mpGame.AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_06747" ) );
 		}
 	}
 }
@@ -3905,7 +3905,7 @@ void idMultiplayerGame::ThrottleUserInfo( void ) {
 		if ( idStr::Icmp( gameLocal.userInfo[ gameLocal.localClientNum ].GetString( ThrottleVars[ i ] ),
 			cvarSystem->GetCVarString( ThrottleVars[ i ] ) ) ) {
 			if ( gameLocal.realClientTime < switchThrottle[ i ] ) {
-				AddChatLine( common->GetLanguageDict()->GetString( "#str_04299" ), common->GetLanguageDict()->GetString( ThrottleVarsInEnglish[ i ] ), ( switchThrottle[ i ] - gameLocal.time ) / 1000 + 1 );
+				AddChatLine( "%s", common->GetLanguageDict()->GetString( "#str_04299" ), common->GetLanguageDict()->GetString( ThrottleVarsInEnglish[ i ] ), ( switchThrottle[ i ] - gameLocal.time ) / 1000 + 1 );
 				cvarSystem->SetCVarString( ThrottleVars[ i ], gameLocal.userInfo[ gameLocal.localClientNum ].GetString( ThrottleVars[ i ] ) );
 			} else {
 				switchThrottle[ i ] = gameLocal.time + ThrottleDelay[ i ] * 1000;

--- a/d3xp/MultiplayerGame.h
+++ b/d3xp/MultiplayerGame.h
@@ -156,7 +156,7 @@ public:
 	// updates frag counts and potentially ends the match in sudden death
 	void			PlayerDeath( idPlayer *dead, idPlayer *killer, bool telefrag );
 
-	void			AddChatLine( const char *fmt, ... ) id_attribute((format(printf,2,3)));
+	void			AddChatLine( const char *fmt, ... );
 
 	void			UpdateMainGui( void );
 	idUserInterface*StartMenu( void );

--- a/d3xp/gamesys/SysCmds.cpp
+++ b/d3xp/gamesys/SysCmds.cpp
@@ -714,7 +714,7 @@ Cmd_AddChatLine_f
 ==================
 */
 static void Cmd_AddChatLine_f( const idCmdArgs &args ) {
-	gameLocal.mpGame.AddChatLine( "%s", args.Argv( 1 ) );
+	gameLocal.mpGame.AddChatLine( args.Argv( 1 ) );
 }
 
 /*

--- a/d3xp/gamesys/SysCmds.cpp
+++ b/d3xp/gamesys/SysCmds.cpp
@@ -714,7 +714,7 @@ Cmd_AddChatLine_f
 ==================
 */
 static void Cmd_AddChatLine_f( const idCmdArgs &args ) {
-	gameLocal.mpGame.AddChatLine( args.Argv( 1 ) );
+	gameLocal.mpGame.AddChatLine( "%s", args.Argv( 1 ) );
 }
 
 /*
@@ -1316,7 +1316,7 @@ static void PrintFloat( float f ) {
 		buf[i] = ' ';
 	}
 	buf[i] = '\0';
-	gameLocal.Printf( buf );
+	gameLocal.Printf( "%s", buf );
 }
 
 /*

--- a/d3xp/script/Script_Thread.cpp
+++ b/d3xp/script/Script_Thread.cpp
@@ -885,7 +885,7 @@ void idThread::Error( const char *fmt, ... ) const {
 	vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
-	interpreter.Error( text );
+	interpreter.Error( "%s", text );
 }
 
 /*
@@ -901,7 +901,7 @@ void idThread::Warning( const char *fmt, ... ) const {
 	vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
-	interpreter.Warning( text );
+	interpreter.Warning( "%s", text );
 }
 
 /*

--- a/framework/CVarSystem.cpp
+++ b/framework/CVarSystem.cpp
@@ -1216,7 +1216,7 @@ void idCVarSystemLocal::ListByFlags( const idCmdArgs &args, cvarFlags_t flags ) 
 				string += ( cvar->GetFlags() & CVAR_ARCHIVE ) ?		"AR "	: "   ";
 				string += ( cvar->GetFlags() & CVAR_MODIFIED ) ?	"MO "	: "   ";
 				string += "\n";
-				common->Printf( string );
+				common->Printf( "%s", string );
 			}
 			break;
 		}

--- a/framework/CVarSystem.cpp
+++ b/framework/CVarSystem.cpp
@@ -1216,7 +1216,7 @@ void idCVarSystemLocal::ListByFlags( const idCmdArgs &args, cvarFlags_t flags ) 
 				string += ( cvar->GetFlags() & CVAR_ARCHIVE ) ?		"AR "	: "   ";
 				string += ( cvar->GetFlags() & CVAR_MODIFIED ) ?	"MO "	: "   ";
 				string += "\n";
-				common->Printf( "%s", string );
+				common->Printf( "%s", string.c_str() );
 			}
 			break;
 		}

--- a/framework/Common.cpp
+++ b/framework/Common.cpp
@@ -2523,7 +2523,7 @@ void idCommonLocal::Frame( void ) {
 
 		// the FPU stack better be empty at this point or some bad code or compiler bug left values on the stack
 		if ( !Sys_FPU_StackIsEmpty() ) {
-			Printf( Sys_FPU_GetState() );
+			Printf( "%s", Sys_FPU_GetState() );
 			FatalError( "idCommon::Frame: the FPU stack is not empty at the end of the frame\n" );
 		}
 	}

--- a/framework/Common.h
+++ b/framework/Common.h
@@ -165,20 +165,20 @@ public:
 	virtual void				SetRefreshOnPrint( bool set ) = 0;
 
 								// Prints message to the console, which may cause a screen update if com_refreshOnPrint is set.
-	virtual void				Printf( const char *fmt, ... ) = 0;
+	virtual void				Printf( const char *fmt, ... )id_attribute((format(printf,2,3))) = 0;
 
 								// Same as Printf, with a more usable API - Printf pipes to this.
 	virtual void				VPrintf( const char *fmt, va_list arg ) = 0;
 
 								// Prints message that only shows up if the "developer" cvar is set,
 								// and NEVER forces a screen update, which could cause reentrancy problems.
-	virtual void				DPrintf( const char *fmt, ... ) = 0;
+	virtual void				DPrintf( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
 
 								// Prints WARNING %s message and adds the warning message to a queue for printing later on.
-	virtual void				Warning( const char *fmt, ... ) = 0;
+	virtual void				Warning( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
 
 								// Prints WARNING %s message in yellow that only shows up if the "developer" cvar is set.
-	virtual void				DWarning( const char *fmt, ...) = 0;
+	virtual void				DWarning( const char *fmt, ...) id_attribute((format(printf,2,3))) = 0;
 
 								// Prints all queued warnings.
 	virtual void				PrintWarnings( void ) = 0;
@@ -188,11 +188,11 @@ public:
 
 								// Issues a C++ throw. Normal errors just abort to the game loop,
 								// which is appropriate for media or dynamic logic errors.
-	virtual void				Error( const char *fmt, ... ) = 0;
+	virtual void				Error( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
 
 								// Fatal errors quit all the way to a system dialog box, which is appropriate for
 								// static internal errors or cases where the system may be corrupted.
-	virtual void				FatalError( const char *fmt, ... ) = 0;
+	virtual void				FatalError( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
 
 								// Returns a pointer to the dictionary with language specific strings.
 	virtual const idLangDict *	GetLanguageDict( void ) = 0;

--- a/framework/Common.h
+++ b/framework/Common.h
@@ -165,20 +165,20 @@ public:
 	virtual void				SetRefreshOnPrint( bool set ) = 0;
 
 								// Prints message to the console, which may cause a screen update if com_refreshOnPrint is set.
-	virtual void				Printf( const char *fmt, ... )id_attribute((format(printf,2,3))) = 0;
+	virtual void				Printf( const char *fmt, ... ) = 0;
 
 								// Same as Printf, with a more usable API - Printf pipes to this.
 	virtual void				VPrintf( const char *fmt, va_list arg ) = 0;
 
 								// Prints message that only shows up if the "developer" cvar is set,
 								// and NEVER forces a screen update, which could cause reentrancy problems.
-	virtual void				DPrintf( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
+	virtual void				DPrintf( const char *fmt, ... ) = 0;
 
 								// Prints WARNING %s message and adds the warning message to a queue for printing later on.
-	virtual void				Warning( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
+	virtual void				Warning( const char *fmt, ... ) = 0;
 
 								// Prints WARNING %s message in yellow that only shows up if the "developer" cvar is set.
-	virtual void				DWarning( const char *fmt, ...) id_attribute((format(printf,2,3))) = 0;
+	virtual void				DWarning( const char *fmt, ...) = 0;
 
 								// Prints all queued warnings.
 	virtual void				PrintWarnings( void ) = 0;
@@ -188,11 +188,11 @@ public:
 
 								// Issues a C++ throw. Normal errors just abort to the game loop,
 								// which is appropriate for media or dynamic logic errors.
-	virtual void				Error( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
+	virtual void				Error( const char *fmt, ... ) = 0;
 
 								// Fatal errors quit all the way to a system dialog box, which is appropriate for
 								// static internal errors or cases where the system may be corrupted.
-	virtual void				FatalError( const char *fmt, ... ) id_attribute((format(printf,2,3))) = 0;
+	virtual void				FatalError( const char *fmt, ... ) = 0;
 
 								// Returns a pointer to the dictionary with language specific strings.
 	virtual const idLangDict *	GetLanguageDict( void ) = 0;

--- a/framework/Console.cpp
+++ b/framework/Console.cpp
@@ -266,7 +266,7 @@ float SCR_DrawAsyncStats( float y ) {
 
 		idStr msg;
 		idAsyncNetwork::server.GetAsyncStatsAvgMsg( msg );
-		SCR_DrawTextRightAlign( y, msg.c_str() );
+		SCR_DrawTextRightAlign( y, "%s", msg.c_str() );
 
 	} else if ( idAsyncNetwork::client.IsActive() ) {
 

--- a/framework/DeclManager.cpp
+++ b/framework/DeclManager.cpp
@@ -1028,10 +1028,10 @@ void idDeclManagerLocal::LoadManual( )
 				pageB = 0;
 			}
 
-			f->Printf( "%s", va("skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
+			f->Printf( "%s", "skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
 				i, i+1,
 				pageA, imageNames[i].c_str(),
-				pageB, imageNames[i+1].c_str() ));
+				pageB, imageNames[i+1].c_str() );
 		}
 		
 		

--- a/framework/DeclManager.cpp
+++ b/framework/DeclManager.cpp
@@ -1028,10 +1028,10 @@ void idDeclManagerLocal::LoadManual( )
 				pageB = 0;
 			}
 
-			f->Printf( "%s", va("skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
+			f->Printf( "skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
 				i, i+1,
 				pageA, imageNames[i].c_str(),
-				pageB, imageNames[i+1].c_str() ));
+				pageB, imageNames[i+1].c_str() );
 		}
 		
 		

--- a/framework/DeclManager.cpp
+++ b/framework/DeclManager.cpp
@@ -1028,10 +1028,10 @@ void idDeclManagerLocal::LoadManual( )
 				pageB = 0;
 			}
 
-			f->Printf( "%s", "skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
+			f->Printf( va("skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
 				i, i+1,
 				pageA, imageNames[i].c_str(),
-				pageB, imageNames[i+1].c_str() );
+				pageB, imageNames[i+1].c_str() ));
 		}
 		
 		

--- a/framework/DeclManager.cpp
+++ b/framework/DeclManager.cpp
@@ -1028,7 +1028,7 @@ void idDeclManagerLocal::LoadManual( )
 				pageB = 0;
 			}
 
-			f->Printf( va("skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
+			f->Printf( "%s", va("skin manualpage_%d_%d\n{\nmodels/weapon_map/page_%d  %s\nmodels/weapon_map/page_%d  %s\n}\n\n",
 				i, i+1,
 				pageA, imageNames[i].c_str(),
 				pageB, imageNames[i+1].c_str() ));

--- a/framework/EditField.cpp
+++ b/framework/EditField.cpp
@@ -282,7 +282,7 @@ void idEditField::AutoComplete( void ) {
 		autoComplete = globalAutoComplete;
 
 		// and print it
-		idStr::snPrintf( buffer, sizeof( buffer ), autoComplete.currentMatch );
+		idStr::snPrintf( buffer, sizeof( buffer ), "%s", autoComplete.currentMatch );
 		if ( autoComplete.length > (int)strlen( buffer ) ) {
 			autoComplete.length = strlen( buffer );
 		}

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -33,7 +33,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #define	MAX_PRINT_MSG		4096
 
-#if (__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#if defined(__GNUC__) && ((__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
@@ -150,7 +150,7 @@ int FS_WriteFloatString( char *buf, const char *fmt, va_list argPtr ) {
 	return index;
 }
 
-#if (__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+#if defined(__GNUC__) && ((__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic pop
 #endif
 

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -34,6 +34,8 @@ If you have questions concerning this license or the applicable additional terms
 #define	MAX_PRINT_MSG		4096
 
 #pragma GCC diagnostic push
+// FS_WriteFloatString generates format strings programmatically; temporarily disable GCC's format-security
+// warning, if enabled, across the extent of the function definition
 #pragma GCC diagnostic ignored "-Wformat-security"
 
 /*

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -73,40 +73,40 @@ int FS_WriteFloatString( char *buf, const char *fmt, va_list argPtr ) {
 							index += sprintf( buf+index, "%s", tmp.c_str() );
 						}
 						else {
-							index += sprintf( buf+index, "%s", format.c_str(), f );
+							index += sprintf( buf+index, format.c_str(), f );
 						}
 						break;
 					case 'd':
 					case 'i':
 						i = va_arg( argPtr, int );
-						index += sprintf( buf+index, "%s", format.c_str(), i );
+						index += sprintf( buf+index, format.c_str(), i );
 						break;
 					case 'u':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, "%s", format.c_str(), u );
+						index += sprintf( buf+index, format.c_str(), u );
 						break;
 					case 'o':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, "%s", format.c_str(), u );
+						index += sprintf( buf+index, format.c_str(), u );
 						break;
 					case 'x':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, "%s", format.c_str(), u );
+						index += sprintf( buf+index, format.c_str(), u );
 						break;
 					case 'X':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, "%s", format.c_str(), u );
+						index += sprintf( buf+index, format.c_str(), u );
 						break;
 					case 'c':
 						i = va_arg( argPtr, int );
-						index += sprintf( buf+index, "%s", format.c_str(), (char) i );
+						index += sprintf( buf+index, format.c_str(), (char) i );
 						break;
 					case 's':
 						str = va_arg( argPtr, char * );
-						index += sprintf( buf+index, "%s", format.c_str(), str );
+						index += sprintf( buf+index, format.c_str(), str );
 						break;
 					case '%':
-						index += sprintf( buf+index, "%s", format.c_str() );
+						index += sprintf( buf+index, format.c_str() );
 						break;
 					default:
 						common->Error( "FS_WriteFloatString: invalid format %s", format.c_str() );

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -33,7 +33,7 @@ If you have questions concerning this license or the applicable additional terms
 
 #define	MAX_PRINT_MSG		4096
 
-#if __GNUC__ >= 5 || __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#if (__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
@@ -150,7 +150,7 @@ int FS_WriteFloatString( char *buf, const char *fmt, va_list argPtr ) {
 	return index;
 }
 
-#if __GNUC__ >= 5 || __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#if (__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 #pragma GCC diagnostic pop
 #endif
 

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -73,40 +73,40 @@ int FS_WriteFloatString( char *buf, const char *fmt, va_list argPtr ) {
 							index += sprintf( buf+index, "%s", tmp.c_str() );
 						}
 						else {
-							index += sprintf( buf+index, format.c_str(), f );
+							index += sprintf( buf+index, "%s", format.c_str(), f );
 						}
 						break;
 					case 'd':
 					case 'i':
 						i = va_arg( argPtr, int );
-						index += sprintf( buf+index, format.c_str(), i );
+						index += sprintf( buf+index, "%s", format.c_str(), i );
 						break;
 					case 'u':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, format.c_str(), u );
+						index += sprintf( buf+index, "%s", format.c_str(), u );
 						break;
 					case 'o':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, format.c_str(), u );
+						index += sprintf( buf+index, "%s", format.c_str(), u );
 						break;
 					case 'x':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, format.c_str(), u );
+						index += sprintf( buf+index, "%s", format.c_str(), u );
 						break;
 					case 'X':
 						u = va_arg( argPtr, unsigned int );
-						index += sprintf( buf+index, format.c_str(), u );
+						index += sprintf( buf+index, "%s", format.c_str(), u );
 						break;
 					case 'c':
 						i = va_arg( argPtr, int );
-						index += sprintf( buf+index, format.c_str(), (char) i );
+						index += sprintf( buf+index, "%s", format.c_str(), (char) i );
 						break;
 					case 's':
 						str = va_arg( argPtr, char * );
-						index += sprintf( buf+index, format.c_str(), str );
+						index += sprintf( buf+index, "%s", format.c_str(), str );
 						break;
 					case '%':
-						index += sprintf( buf+index, format.c_str() );
+						index += sprintf( buf+index, "%s", format.c_str() );
 						break;
 					default:
 						common->Error( "FS_WriteFloatString: invalid format %s", format.c_str() );

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -33,6 +33,11 @@ If you have questions concerning this license or the applicable additional terms
 
 #define	MAX_PRINT_MSG		4096
 
+#if __GNUC__ >= 5 || __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+#endif
+
 /*
 =================
 FS_WriteFloatString
@@ -144,6 +149,10 @@ int FS_WriteFloatString( char *buf, const char *fmt, va_list argPtr ) {
 
 	return index;
 }
+
+#if __GNUC__ >= 5 || __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic pop
+#endif
 
 /*
 =================================================================================

--- a/framework/File.cpp
+++ b/framework/File.cpp
@@ -33,10 +33,8 @@ If you have questions concerning this license or the applicable additional terms
 
 #define	MAX_PRINT_MSG		4096
 
-#if defined(__GNUC__) && ((__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
-#endif
 
 /*
 =================
@@ -150,9 +148,7 @@ int FS_WriteFloatString( char *buf, const char *fmt, va_list argPtr ) {
 	return index;
 }
 
-#if defined(__GNUC__) && ((__GNUC__ >= 5) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
 #pragma GCC diagnostic pop
-#endif
 
 /*
 =================================================================================

--- a/framework/FileSystem.cpp
+++ b/framework/FileSystem.cpp
@@ -2003,7 +2003,7 @@ void idFileSystemLocal::Path_f( const idCmdArgs &args ) {
 				} else {
 					status += ")\n";
 				}
-				common->Printf( status.c_str() );
+				common->Printf( "%s", status.c_str() );
 			}
 			else
 			{

--- a/framework/FileSystem.cpp
+++ b/framework/FileSystem.cpp
@@ -3991,7 +3991,7 @@ void idFileSystemLocal::FindDLL( const char *name, char _dllPath[ MAX_OSPATH ], 
 	} else {
 		dllPath = "";
 	}
-	idStr::snPrintf( _dllPath, MAX_OSPATH, dllPath.c_str() );
+	idStr::snPrintf( _dllPath, MAX_OSPATH, "%s", dllPath.c_str() );
 }
 
 /*

--- a/framework/Session.cpp
+++ b/framework/Session.cpp
@@ -876,7 +876,7 @@ void idSessionLocal::StopPlayingRenderDemo() {
 		float	demoFPS = numDemoFrames / demoSeconds;
 		idStr	message = va( "%i frames rendered in %3.1f seconds = %3.1f fps\n", numDemoFrames, demoSeconds, demoFPS );
 
-		common->Printf( "%s", message );
+		common->Printf( "%s", message.c_str() );
 		if ( timeDemo == TD_YES_THEN_QUIT ) {
 			cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "quit\n" );
 		} else {

--- a/framework/Session.cpp
+++ b/framework/Session.cpp
@@ -876,7 +876,7 @@ void idSessionLocal::StopPlayingRenderDemo() {
 		float	demoFPS = numDemoFrames / demoSeconds;
 		idStr	message = va( "%i frames rendered in %3.1f seconds = %3.1f fps\n", numDemoFrames, demoSeconds, demoFPS );
 
-		common->Printf( message );
+		common->Printf( "%s", message );
 		if ( timeDemo == TD_YES_THEN_QUIT ) {
 			cmdSystem->BufferCommandText( CMD_EXEC_APPEND, "quit\n" );
 		} else {

--- a/framework/async/AsyncClient.cpp
+++ b/framework/async/AsyncClient.cpp
@@ -1433,7 +1433,7 @@ bool idAsyncClient::ValidatePureServerChecksums( const netadr_t from, const idBi
 					message += va( common->GetLanguageDict()->GetString( "#str_06750" ), missingGamePakChecksum );
 				}
 
-				common->Printf( "%s", message );
+				common->Printf( "%s", message.c_str() );
 				cmdSystem->BufferCommandText( CMD_EXEC_NOW, "disconnect" );
 				session->MessageBox( MSG_OK, message, common->GetLanguageDict()->GetString( "#str_06735" ), true );
 			} else {

--- a/framework/async/AsyncClient.cpp
+++ b/framework/async/AsyncClient.cpp
@@ -1433,7 +1433,7 @@ bool idAsyncClient::ValidatePureServerChecksums( const netadr_t from, const idBi
 					message += va( common->GetLanguageDict()->GetString( "#str_06750" ), missingGamePakChecksum );
 				}
 
-				common->Printf( message );
+				common->Printf( "%s", message );
 				cmdSystem->BufferCommandText( CMD_EXEC_NOW, "disconnect" );
 				session->MessageBox( MSG_OK, message, common->GetLanguageDict()->GetString( "#str_06735" ), true );
 			} else {

--- a/framework/async/AsyncServer.cpp
+++ b/framework/async/AsyncServer.cpp
@@ -2533,7 +2533,7 @@ void idAsyncServer::RunFrame( void ) {
 
 			idStr msg;
 			GetAsyncStatsAvgMsg( msg );
-			common->Printf( va( "%s\n", msg.c_str() ) );
+			common->Printf( "%s", msg.c_str() );
 
 			nextAsyncStatsTime = serverTime + 1000;
 		}

--- a/framework/async/AsyncServer.cpp
+++ b/framework/async/AsyncServer.cpp
@@ -2533,7 +2533,7 @@ void idAsyncServer::RunFrame( void ) {
 
 			idStr msg;
 			GetAsyncStatsAvgMsg( msg );
-			common->Printf( "%s", msg.c_str() );
+			common->Printf( "%s\n", msg.c_str() );
 
 			nextAsyncStatsTime = serverTime + 1000;
 		}

--- a/framework/async/AsyncServer.cpp
+++ b/framework/async/AsyncServer.cpp
@@ -1456,7 +1456,7 @@ void idAsyncServer::ProcessAuthMessage( const idBitMsg &msg ) {
 		return;
 	}
 	
-	idStr::snPrintf( challenges[ i ].guid, 12, client_guid );
+	idStr::snPrintf( challenges[ i ].guid, 12, "%s", client_guid );
 	if ( reply == AUTH_OK ) {
 		challenges[ i ].authState = CDK_OK;
 		common->Printf( "client %s %s is authed\n", Sys_NetAdrToString( client_from ), client_guid );
@@ -1743,7 +1743,7 @@ void idAsyncServer::ProcessConnectMessage( const netadr_t from, const idBitMsg &
 			PrintOOB( from, SERVER_PRINT_MISC, msg );
 		
 			// update the guid in the challenges
-			idStr::snPrintf( challenges[ ichallenge ].guid, sizeof( challenges[ ichallenge ].guid ), guid );
+			idStr::snPrintf( challenges[ ichallenge ].guid, sizeof( challenges[ ichallenge ].guid ), "%s", guid );
 
 			// once auth replied denied, stop sending further requests
 			if ( challenges[ ichallenge ].authReply != AUTH_DENY ) {

--- a/game/Game_local.cpp
+++ b/game/Game_local.cpp
@@ -1068,7 +1068,7 @@ bool idGameLocal::NextMap( void ) {
 	int					i;
 
 	if ( !g_mapCycle.GetString()[0] ) {
-		Printf( common->GetLanguageDict()->GetString( "#str_04294" ) );
+		Printf( "%s", common->GetLanguageDict()->GetString( "#str_04294" ) );
 		return false;
 	}
 	if ( fileSystem->ReadFile( g_mapCycle.GetString(), NULL, NULL ) < 0 ) {

--- a/game/Game_network.cpp
+++ b/game/Game_network.cpp
@@ -714,7 +714,7 @@ void idGameLocal::NetworkEventWarning( const entityNetEvent_t *event, const char
 	va_end( argptr );
 	idStr::Append( buf, sizeof(buf), "\n" );
 
-	common->DWarning( buf );
+	common->DWarning( "%s", buf );
 }
 
 /*

--- a/game/MultiplayerGame.cpp
+++ b/game/MultiplayerGame.cpp
@@ -2566,7 +2566,7 @@ void idMultiplayerGame::ClientStartVote( int clientNum, const char *_voteString 
 	}
 
 	voteString = _voteString;
-	AddChatLine( va( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) ) );
+	AddChatLine( common->GetLanguageDict()->GetString( "#str_04279" ), gameLocal.userInfo[ clientNum ].GetString( "ui_name" ) );
 	gameSoundWorld->PlayShaderDirectly( GlobalSoundStrings[ SND_VOTE ] );
 	if ( clientNum == gameLocal.localClientNum ) {
 		voted = true;

--- a/game/MultiplayerGame.h
+++ b/game/MultiplayerGame.h
@@ -117,7 +117,7 @@ public:
 	// updates frag counts and potentially ends the match in sudden death
 	void			PlayerDeath( idPlayer *dead, idPlayer *killer, bool telefrag );
 
-	void			AddChatLine( const char *fmt, ... ) id_attribute((format(printf,2,3)));
+	void			AddChatLine( const char *fmt, ... );
 
 	void			UpdateMainGui( void );
 	idUserInterface*StartMenu( void );

--- a/game/gamesys/SysCmds.cpp
+++ b/game/gamesys/SysCmds.cpp
@@ -1213,7 +1213,7 @@ static void PrintFloat( float f ) {
 		buf[i] = ' ';
 	}
 	buf[i] = '\0';
-	gameLocal.Printf( buf );
+	gameLocal.Printf( "%s", buf );
 }
 
 /*

--- a/game/script/Script_Thread.cpp
+++ b/game/script/Script_Thread.cpp
@@ -792,7 +792,7 @@ void idThread::Error( const char *fmt, ... ) const {
 	vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
-	interpreter.Error( text );
+	interpreter.Error( "%s", text );
 }
 
 /*
@@ -808,7 +808,7 @@ void idThread::Warning( const char *fmt, ... ) const {
 	vsprintf( text, fmt, argptr );
 	va_end( argptr );
 
-	interpreter.Warning( text );
+	interpreter.Warning( "%s", text );
 }
 
 /*

--- a/idlib/Parser.cpp
+++ b/idlib/Parser.cpp
@@ -323,7 +323,7 @@ void idParser::Error( const char *str, ... ) const {
 	vsprintf(text, str, ap);
 	va_end(ap);
 	if ( idParser::scriptstack ) {
-		idParser::scriptstack->Error( text );
+		idParser::scriptstack->Error( "%s", text );
 	}
 }
 
@@ -340,7 +340,7 @@ void idParser::Warning( const char *str, ... ) const {
 	vsprintf(text, str, ap);
 	va_end(ap);
 	if ( idParser::scriptstack ) {
-		idParser::scriptstack->Warning( text );
+		idParser::scriptstack->Warning( "%s", text );
 	}
 }
 

--- a/idlib/math/Simd.cpp
+++ b/idlib/math/Simd.cpp
@@ -319,7 +319,7 @@ PrintClocks
 void PrintClocks( char *string, int dataCount, int clocks, int otherClocks = 0 ) {
 	int i;
 
-	idLib::common->Printf( string );
+	idLib::common->Printf( "%s", string );
 	for ( i = idStr::LengthWithoutColors(string); i < 48; i++ ) {
 		idLib::common->Printf(" ");
 	}

--- a/renderer/Model_ma.cpp
+++ b/renderer/Model_ma.cpp
@@ -695,9 +695,11 @@ void MA_ParseMesh(idParser& parser) {
 		pMesh->vertexes[(int)pMesh->vertTransforms[i].w] +=  pMesh->vertTransforms[i].ToVec3();
 	}
 
-	common->Printf("MESH %s - parent %s\n", header.name, header.parent);
-	common->Printf("\tverts:%d\n",maGlobal.currentObject->mesh.numVertexes);
-	common->Printf("\tfaces:%d\n",maGlobal.currentObject->mesh.numFaces);
+	if (maGlobal.verbose) {
+		common->Printf("MESH %s - parent %s\n", header.name, header.parent);
+		common->Printf("\tverts:%d\n",maGlobal.currentObject->mesh.numVertexes);
+		common->Printf("\tfaces:%d\n",maGlobal.currentObject->mesh.numFaces);
+	}
 }
 
 void MA_ParseFileNode(idParser& parser) {

--- a/renderer/Model_ma.cpp
+++ b/renderer/Model_ma.cpp
@@ -40,8 +40,6 @@ If you have questions concerning this license or the applicable additional terms
 */
 	
 
-#define MA_VERBOSE( x ) { if ( maGlobal.verbose ) { common->Printf x ; } }
-
 // working variables used during parsing
 typedef struct {
 	bool			verbose;
@@ -696,10 +694,10 @@ void MA_ParseMesh(idParser& parser) {
 	for(int i = 0; i < pMesh->numVertTransforms; i++) {
 		pMesh->vertexes[(int)pMesh->vertTransforms[i].w] +=  pMesh->vertTransforms[i].ToVec3();
 	}
-	
-	MA_VERBOSE((va("MESH %s - parent %s\n", header.name, header.parent)));
-	MA_VERBOSE((va("\tverts:%d\n",maGlobal.currentObject->mesh.numVertexes)));
-	MA_VERBOSE((va("\tfaces:%d\n",maGlobal.currentObject->mesh.numFaces)));
+
+	common->Printf("MESH %s - parent %s\n", header.name, header.parent);
+	common->Printf("\tverts:%d\n",maGlobal.currentObject->mesh.numVertexes);
+	common->Printf("\tfaces:%d\n",maGlobal.currentObject->mesh.numFaces);
 }
 
 void MA_ParseFileNode(idParser& parser) {

--- a/renderer/RenderSystem_init.cpp
+++ b/renderer/RenderSystem_init.cpp
@@ -629,7 +629,7 @@ static void R_CheckPortableExtensions( void ) {
 	// check for minimum set
 	if ( !glConfig.multitextureAvailable || !glConfig.textureEnvCombineAvailable || !glConfig.cubeMapAvailable
 		|| !glConfig.envDot3Available ) {
-			common->Error( common->GetLanguageDict()->GetString( "#str_06780" ) );
+			common->Error( "%s", common->GetLanguageDict()->GetString( "#str_06780" ) );
 	}
 
  	// GL_EXT_depth_bounds_test

--- a/tools/compilers/aas/Brush.cpp
+++ b/tools/compilers/aas/Brush.cpp
@@ -55,7 +55,7 @@ void DisplayRealTimeString( char *string, ... ) {
 		va_start( argPtr, string );
 		vsprintf( buf, string, argPtr );
 		va_end( argPtr );
-		common->Printf( buf );
+		common->Printf( "%s", buf );
 		lastUpdateTime = time;
 	}
 }

--- a/ui/ListGUI.cpp
+++ b/ui/ListGUI.cpp
@@ -76,7 +76,7 @@ int idListGUILocal::GetSelection( char *s, int size, int _sel ) const {
 		return -1;
 	}
 	if ( s ) {
-		idStr::snPrintf( s, size, m_pGUI->State().GetString( va( "%s_item_%i", m_name.c_str(), sel ), "" ) );
+		idStr::snPrintf( s, size, "%s", m_pGUI->State().GetString( va( "%s_item_%i", m_name.c_str(), sel ), "" ) );
 	}
 	// don't let overflow
 	if ( sel >= m_ids.Num() ) {


### PR DESCRIPTION
First of all I have to admit that it's been a long time since I dabbled with any C/C++ coding, and I was never an expert.  So this has a good chunk of "I'm not certain about all the implications of what I'm doing".

This changeset is related to an attempt I'm making to create a Debian package for `quadrilateralcowboy`.

With the changes here in place -- and some basic draft Debian packaging rules that I'm putting together -- the package does successfully compile, although I haven't run the game yet to see how functional it is.

In particular, the changes here address [`-Wformat-security` warnings/errors](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) at compile-time.