### PR TITLE
Fixup: add missing 'return' statement to idAudioHardwareLinux::GetNumberOfSpeakers

### DIFF
--- a/sys/linux/sound_oal.cpp
+++ b/sys/linux/sound_oal.cpp
@@ -42,7 +42,7 @@ public:
 	int		GetMixBufferSize( void )  { return 0; }
 	
 	int		GetNumberOfSpeakers( void ) {
-		idSoundSystemLocal::s_numberOfSpeakers.GetInteger();
+		return idSoundSystemLocal::s_numberOfSpeakers.GetInteger();
 	}
 
 	// doesn't support write API


### PR DESCRIPTION
With credit to @DanielGibson for [tracking this bug down](https://github.com/blendogames/quadrilateralcowboy/pull/4#issuecomment-1363488897).

Resolves #5.