### PR TITLE
Nitpick: prefer relative include paths in glimp_dlopen.cpp.m4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ SET(CMAKE_INSTALL_RPATH ${BIN_RPATH})
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 # Include Directories
-INCLUDE_DIRECTORIES(. sound/OggVorbis/vorbissrc/)
+INCLUDE_DIRECTORIES(sound/OggVorbis/vorbissrc/)
 
 # Source Lists
 SET(QC_SRC

--- a/sys/linux/glimp_dlopen.cpp.m4
+++ b/sys/linux/glimp_dlopen.cpp.m4
@@ -1,6 +1,6 @@
-#include "idlib/precompiled.h"
-#include "renderer/tr_local.h"
-#include "sys/linux/local.h"
+#include "../../idlib/precompiled.h"
+#include "../../renderer/tr_local.h"
+#include "../../sys/linux/local.h"
 #include "glimp_local.h"
 
 #include <dlfcn.h>


### PR DESCRIPTION
Nitpick: prefer relative include paths in glimp_dlopen.cpp.m4 over adding the base directory to the include path.

(discovered during some local rebuilds - in particular, after removing the `OggVorbis` sources from the project, and removing the `.` directory reference at the same time without realizing that it was a dependency)