### PR TITLE
From upstream: Some spelling error fixes found during Debian build

### DIFF
--- a/d3xp/ai/AI_pathing.cpp
+++ b/d3xp/ai/AI_pathing.cpp
@@ -1329,7 +1329,7 @@ static int Ballistics( const idVec3 &start, const idVec3 &end, float speed, floa
 =====================
 HeightForTrajectory
 
-Returns the maximum hieght of a given trajectory
+Returns the maximum height of a given trajectory
 =====================
 */
 static float HeightForTrajectory( const idVec3 &start, float zVel, float gravity ) {

--- a/d3xp/gamesys/SysCvar.cpp
+++ b/d3xp/gamesys/SysCvar.cpp
@@ -152,8 +152,8 @@ idCVar g_healthTakeLimit(			"g_healthTakeLimit",		"25",			CVAR_GAME | CVAR_INTEG
 
 
 idCVar g_showPVS(					"g_showPVS",				"0",			CVAR_GAME | CVAR_INTEGER, "", 0, 2 );
-idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and thier targets.  hidden entities are drawn grey." );
-idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and thier targets (green).  disabled triggers are drawn grey." );
+idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and their targets.  hidden entities are drawn grey." );
+idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and their targets (green).  disabled triggers are drawn grey." );
 idCVar g_showCollisionWorld(		"g_showCollisionWorld",		"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionModels(		"g_showCollisionModels",	"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionTraces(		"g_showCollisionTraces",	"0",			CVAR_GAME | CVAR_BOOL, "" );

--- a/d3xp/gamesys/SysCvar.cpp
+++ b/d3xp/gamesys/SysCvar.cpp
@@ -474,4 +474,4 @@ idCVar g_xp_bind_run_once( "g_xp_bind_run_once", "0", CVAR_GAME | CVAR_BOOL | CV
 
 idCVar net_serverDownload(			"net_serverDownload",		"0",			CVAR_GAME | CVAR_INTEGER | CVAR_ARCHIVE, "enable server download redirects. 0: off 1: redirect to si_serverURL 2: use builtin download. see net_serverDl cvars for configuration" );
 idCVar net_serverDlBaseURL(			"net_serverDlBaseURL",		"",				CVAR_GAME | CVAR_ARCHIVE, "base URL for the download redirection" );
-idCVar net_serverDlTable(			"net_serverDlTable",		"",				CVAR_GAME | CVAR_ARCHIVE, "pak names for which download is provided, seperated by ;" );
+idCVar net_serverDlTable(			"net_serverDlTable",		"",				CVAR_GAME | CVAR_ARCHIVE, "pak names for which download is provided, separated by ;" );

--- a/d3xp/gamesys/SysCvar.cpp
+++ b/d3xp/gamesys/SysCvar.cpp
@@ -348,7 +348,7 @@ idCVar rb_showVelocity(				"rb_showVelocity",			"0",			CVAR_GAME | CVAR_BOOL, "s
 idCVar rb_showActive(				"rb_showActive",			"0",			CVAR_GAME | CVAR_BOOL, "show rigid bodies that are not at rest" );
 
 // The default values for player movement cvars are set in def/player.def
-idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate hieght the player can jump" );
+idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate height the player can jump" );
 idCVar pm_stepsize(					"pm_stepsize",				"16",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "maximum height the player can step up without jumping" );
 idCVar pm_crouchspeed(				"pm_crouchspeed",			"80",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while crouched" );
 idCVar pm_walkspeed(				"pm_walkspeed",				"140",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while walking" );

--- a/d3xp/physics/Physics_AF.cpp
+++ b/d3xp/physics/Physics_AF.cpp
@@ -3068,7 +3068,7 @@ void idAFConstraint_Contact::ApplyFriction( float invTimeStep ) {
 		return;
 	}
 
-	// seperate friction per contact is silly but it's fast and often looks close enough
+	// separate friction per contact is silly but it's fast and often looks close enough
 	if ( af_useImpulseFriction.GetBool() ) {
 
 		impulse.SetData( 6, VECX_ALLOCA( 6 ) );
@@ -7001,7 +7001,7 @@ void idPhysics_AF::BuildTrees( void ) {
 		}
 
 		if ( trees.Num() > 1 ) {
-			gameLocal.Warning( "Articulated figure has multiple seperate tree structures for entity '%s' type '%s'.",
+			gameLocal.Warning( "Articulated figure has multiple separate tree structures for entity '%s' type '%s'.",
 								self->name.c_str(), self->GetType()->classname );
 		}
 

--- a/framework/DeclAF.cpp
+++ b/framework/DeclAF.cpp
@@ -887,7 +887,7 @@ bool idDeclAF::ParseBody( idLexer &src ) {
 				src.Error( "custom models not yet implemented" );
 				return false;
 			} else {
-				src.Error( "unkown model type %s", token.c_str() );
+				src.Error( "unknown model type %s", token.c_str() );
 				return false;
 			}
 		} else if ( !token.Icmp( "origin" ) ) {

--- a/game/ai/AI_pathing.cpp
+++ b/game/ai/AI_pathing.cpp
@@ -1328,7 +1328,7 @@ static int Ballistics( const idVec3 &start, const idVec3 &end, float speed, floa
 =====================
 HeightForTrajectory
 
-Returns the maximum hieght of a given trajectory
+Returns the maximum height of a given trajectory
 =====================
 */
 static float HeightForTrajectory( const idVec3 &start, float zVel, float gravity ) {

--- a/game/gamesys/SysCvar.cpp
+++ b/game/gamesys/SysCvar.cpp
@@ -227,7 +227,7 @@ idCVar rb_showVelocity(				"rb_showVelocity",			"0",			CVAR_GAME | CVAR_BOOL, "s
 idCVar rb_showActive(				"rb_showActive",			"0",			CVAR_GAME | CVAR_BOOL, "show rigid bodies that are not at rest" );
 
 // The default values for player movement cvars are set in def/player.def
-idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate hieght the player can jump" );
+idCVar pm_jumpheight(				"pm_jumpheight",			"48",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "approximate height the player can jump" );
 idCVar pm_stepsize(					"pm_stepsize",				"16",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "maximum height the player can step up without jumping" );
 idCVar pm_crouchspeed(				"pm_crouchspeed",			"80",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while crouched" );
 idCVar pm_walkspeed(				"pm_walkspeed",				"140",			CVAR_GAME | CVAR_NETWORKSYNC | CVAR_FLOAT, "speed the player can move while walking" );

--- a/game/gamesys/SysCvar.cpp
+++ b/game/gamesys/SysCvar.cpp
@@ -129,8 +129,8 @@ idCVar g_healthTakeLimit(			"g_healthTakeLimit",		"25",			CVAR_GAME | CVAR_INTEG
 
 
 idCVar g_showPVS(					"g_showPVS",				"0",			CVAR_GAME | CVAR_INTEGER, "", 0, 2 );
-idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and thier targets.  hidden entities are drawn grey." );
-idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and thier targets (green).  disabled triggers are drawn grey." );
+idCVar g_showTargets(				"g_showTargets",			"0",			CVAR_GAME | CVAR_BOOL, "draws entities and their targets.  hidden entities are drawn grey." );
+idCVar g_showTriggers(				"g_showTriggers",			"0",			CVAR_GAME | CVAR_BOOL, "draws trigger entities (orange) and their targets (green).  disabled triggers are drawn grey." );
 idCVar g_showCollisionWorld(		"g_showCollisionWorld",		"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionModels(		"g_showCollisionModels",	"0",			CVAR_GAME | CVAR_BOOL, "" );
 idCVar g_showCollisionTraces(		"g_showCollisionTraces",	"0",			CVAR_GAME | CVAR_BOOL, "" );

--- a/game/gamesys/SysCvar.cpp
+++ b/game/gamesys/SysCvar.cpp
@@ -330,4 +330,4 @@ idCVar mod_validSkins(				"mod_validSkins",			"skins/characters/player/marine_mp
 
 idCVar net_serverDownload(			"net_serverDownload",		"0",			CVAR_GAME | CVAR_INTEGER | CVAR_ARCHIVE, "enable server download redirects. 0: off 1: redirect to si_serverURL 2: use builtin download. see net_serverDl cvars for configuration" );
 idCVar net_serverDlBaseURL(			"net_serverDlBaseURL",		"",				CVAR_GAME | CVAR_ARCHIVE, "base URL for the download redirection" );
-idCVar net_serverDlTable(			"net_serverDlTable",		"",				CVAR_GAME | CVAR_ARCHIVE, "pak names for which download is provided, seperated by ;" );
+idCVar net_serverDlTable(			"net_serverDlTable",		"",				CVAR_GAME | CVAR_ARCHIVE, "pak names for which download is provided, separated by ;" );

--- a/game/physics/Physics_AF.cpp
+++ b/game/physics/Physics_AF.cpp
@@ -3067,7 +3067,7 @@ void idAFConstraint_Contact::ApplyFriction( float invTimeStep ) {
 		return;
 	}
 
-	// seperate friction per contact is silly but it's fast and often looks close enough
+	// separate friction per contact is silly but it's fast and often looks close enough
 	if ( af_useImpulseFriction.GetBool() ) {
 
 		impulse.SetData( 6, VECX_ALLOCA( 6 ) );
@@ -6955,7 +6955,7 @@ void idPhysics_AF::BuildTrees( void ) {
 		}
 
 		if ( trees.Num() > 1 ) {
-			gameLocal.Warning( "Articulated figure has multiple seperate tree structures for entity '%s' type '%s'.",
+			gameLocal.Warning( "Articulated figure has multiple separate tree structures for entity '%s' type '%s'.",
 								self->name.c_str(), self->GetType()->classname );
 		}
 

--- a/idlib/Lexer.cpp
+++ b/idlib/Lexer.cpp
@@ -188,7 +188,7 @@ const char *idLexer::GetPunctuationFromId( int id ) {
 			return idLexer::punctuations[i].p;
 		}
 	}
-	return "unkown punctuation";
+	return "unknown punctuation";
 }
 
 /*

--- a/idlib/Parser.cpp
+++ b/idlib/Parser.cpp
@@ -3161,7 +3161,7 @@ const char *idParser::GetPunctuationFromId( int id ) {
 			return idParser::punctuations[i].p;
 		}
 	}
-	return "unkown punctuation";
+	return "unknown punctuation";
 }
 
 /*

--- a/renderer/Image_init.cpp
+++ b/renderer/Image_init.cpp
@@ -1550,7 +1550,7 @@ idImage	*idImageManager::ImageFromFile( const char *_name, textureFilter_t filte
 			if ( image_preload.GetBool() && !insideLevelLoad ) {
 				image->referencedOutsideLevelLoad = true;
 				image->ActuallyLoadImage( true, false );	// check for precompressed, load is from front end
-				declManager->MediaPrint( "%ix%i %s (reload for mixed referneces)\n", image->uploadWidth, image->uploadHeight, image->imgName.c_str() );
+				declManager->MediaPrint( "%ix%i %s (reload for mixed references)\n", image->uploadWidth, image->uploadHeight, image->imgName.c_str() );
 			}
 			return image;
 		}

--- a/sys/win32/rc/Radiant.rc
+++ b/sys/win32/rc/Radiant.rc
@@ -1357,7 +1357,7 @@ BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,136,24,42,14
     LTEXT           "This creates a set of stairs using the selected brush as a template. You may optionally specify a rotation angle to be applied to each new step",
                     IDC_STATIC,7,7,120,37
-    LTEXT           "After pressing OK, left click to select a ""height"" point for the stairs. Enough stairs will be created to consume the hieght (Z) between the selected brush and the point you specify",
+    LTEXT           "After pressing OK, left click to select a ""height"" point for the stairs. Enough stairs will be created to consume the height (Z) between the selected brush and the point you specify",
                     IDC_STATIC,7,46,116,53
     LTEXT           "Rotation per step:",IDC_STATIC,7,104,57,8
     EDITTEXT        IDC_EDIT_ROTATION,69,102,40,12,ES_AUTOHSCROLL

--- a/tools/af/DialogAFBody.cpp
+++ b/tools/af/DialogAFBody.cpp
@@ -83,7 +83,7 @@ toolTip_t DialogAFBody::toolTips[] = {
 	{ IDC_BUTTON_CM_BROWSE, "browse custom collision model" },
 	{ IDC_COMBO_BONE_JOINT1, "first joint of bone collision model" },
 	{ IDC_COMBO_BONE_JOINT2, "second joint of bone collision model" },
-	{ IDC_EDIT_CM_HEIGHT, "hieght of the collision model" },
+	{ IDC_EDIT_CM_HEIGHT, "height of the collision model" },
 	{ IDC_EDIT_CM_WIDTH, "width of the collision model" },
 	{ IDC_EDIT_CM_LENGTH, "length of the collision model" },
 	{ IDC_EDIT_CM_NUMSIDES, "number of sides of the collision model" },

--- a/tools/compilers/aas/Brush.cpp
+++ b/tools/compilers/aas/Brush.cpp
@@ -898,7 +898,7 @@ void idBrush::AddBevelsForAxialBox( void ) {
 					// behind this plane, it is a proper edge bevel
 					for ( k = 0; k < sides.Num(); k++ ) {
 
-						// if this plane has allready been used, skip it
+						// if this plane has already been used, skip it
 						if ( plane.Compare( sides[k]->plane, 0.001f, 0.1f ) ) {
 							break;
 						}

--- a/tools/compilers/aas/BrushBSP.cpp
+++ b/tools/compilers/aas/BrushBSP.cpp
@@ -82,7 +82,7 @@ idBrushBSPPortal::AddToNodes
 */
 void idBrushBSPPortal::AddToNodes( idBrushBSPNode *front, idBrushBSPNode *back ) {
 	if ( nodes[0] || nodes[1] ) {
-		common->Error( "AddToNode: allready included" );
+		common->Error( "AddToNode: already included" );
 	}
 
 	assert( front && back );

--- a/tools/compilers/dmap/portals.cpp
+++ b/tools/compilers/dmap/portals.cpp
@@ -105,7 +105,7 @@ AddPortalToNodes
 */
 void AddPortalToNodes (uPortal_t  *p, node_t *front, node_t *back) {
 	if (p->nodes[0] || p->nodes[1]) {
-		common->Error( "AddPortalToNode: allready included");
+		common->Error( "AddPortalToNode: already included");
 	}
 
 	p->nodes[0] = front;
@@ -737,7 +737,7 @@ void FloodAreas_r (node_t *node)
 	int			s;
 
 	if ( node->area != -1 ) {
-		return;		// allready got it
+		return;		// already got it
 	}
 	if ( node->opaque ) {
 		return;
@@ -785,7 +785,7 @@ void FindAreas_r( node_t *node ) {
 	}
 
 	if ( node->area != -1 ) {
-		return;		// allready got it
+		return;		// already got it
 	}
 
 	c_areaFloods = 0;

--- a/tools/radiant/EditorBrush.cpp
+++ b/tools/radiant/EditorBrush.cpp
@@ -2673,7 +2673,7 @@ Brush_AddToList
 */
 void Brush_AddToList(brush_t *b, brush_t *list) {
 	if (b->next || b->prev) {
-		Error("Brush_AddToList: allready linked");
+		Error("Brush_AddToList: already linked");
 	}
 
 	if (list == &selected_brushes || list == &active_brushes) {
@@ -2905,7 +2905,7 @@ void Brush_SelectFaceForDragging(brush_t *b, face_t *f, bool shear) {
 	//AddMovePlane(&f->plane);
 
 	if (c == 0) {
-		return;				// allready completely added
+		return;				// already completely added
 	}
 
 	// select all points on this plane in all brushes the selection

--- a/tools/radiant/EditorEntity.cpp
+++ b/tools/radiant/EditorEntity.cpp
@@ -304,7 +304,7 @@ void Entity_FreeEpairs(entity_t *e) {
  */
 void Entity_AddToList(entity_t *e, entity_t *list) {
 	if (e->next || e->prev) {
-		Error("Entity_AddToList: allready linked");
+		Error("Entity_AddToList: already linked");
 	}
 
 	e->next = list->next;

--- a/tools/radiant/PARSE.CPP
+++ b/tools/radiant/PARSE.CPP
@@ -47,7 +47,7 @@ bool WINAPI GetToken (bool crossline)
 {
 	char    *token_p;
 
-	if (unget)                         // is a token allready waiting?
+	if (unget)                         // is a token already waiting?
 	{
 		unget = false;
 		return true;

--- a/ui/GuiScript.cpp
+++ b/ui/GuiScript.cpp
@@ -364,7 +364,7 @@ bool idGuiScript::Parse(idParser *src) {
 	}
 
 	if (handler == NULL) {
-		src->Error("Uknown script call %s", token.c_str());
+		src->Error("Unknown script call %s", token.c_str());
 	}
 	// now read parms til ;
 	// all parms are read as idWinStr's but will be fixed up later 


### PR DESCRIPTION
Applies changes from dhewm/dhewm3#180:

> - s/allready/already
> - s/Uknown/Unknown
> - s/thier/their

(cherry picked from commit dbb90b756539f19eaf7685169252a6b32fc31b48)

... and dhewm/dhewm3#320:

> - s/referneces/references

(cherry picked from commit 8c699cd030b2e012533f9dea8ef83e125a352deb)

... plus dhewm/dhewm3#108:

> - s/unkown/unknown
> - s/seperate/separate

(cherry picked from commit 16281dfbff4290ad4265c41d1497936c4d272117)

... plus dhewm/dhewm3#504

> - s/hiehgt/height

(cherry picked from commit d57f438db1abb86d5b719abab572420c02f1fc9b)