### PR TITLE
Add weevil pickup logic (fixes game crash on weevil pickup)

### DIFF
--- a/d3xp/weevil.cpp
+++ b/d3xp/weevil.cpp
@@ -230,6 +230,10 @@ void idWeevil::OnGet( void )
 	beamStart->PostEventMS( &EV_Remove, 0 );
 	beamEnd->PostEventMS( &EV_Remove, 0 );
 	plugModel->PostEventMS( &EV_Remove, 0 );
+
+	gameLocal.GetLocalPlayer()->StartSound( "snd_get", SND_CHANNEL_ANY, 0, false, NULL );
+	this->PostEventMS( &EV_Remove, 0 );
+	gameLocal.GetLocalPlayer()->GiveInventoryItem("weapon_weevil");
 }
 
 void idWeevil::Event_isweevilplugconnected( void )


### PR DESCRIPTION
In commit [`03ff854` the `UseFrob(focusFrobEnt, "onGet")` call in `d3xp/Player.cpp` was put in an else block instead of being kept as fallback](https://github.com/blendogames/quadrilateralcowboy/commit/03ff8548cd0232fad62c8af20dc86d5dfbabda83#diff-438b2f3ff143a7ca139f7fde78d04091dcf31611a08b687c5c8cae4d18ee8041R8822-L8824).

This caused the weevil's .script's `onGet()` to not get called anymore, and because the lines added in this PR were missing (unlike for [sentry](https://github.com/blendogames/quadrilateralcowboy/blob/03ff8548cd0232fad62c8af20dc86d5dfbabda83/d3xp/sentry.cpp#L551-L553)/[launcher](https://github.com/blendogames/quadrilateralcowboy/blob/03ff8548cd0232fad62c8af20dc86d5dfbabda83/d3xp/launcher.cpp#L765-L771)), the entity wasn't fully cleared, making every function that uses it deference a null pointer and so making the game crash.

Thanks in advance!