### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
   windows:
     name: Win32
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
       with:
@@ -168,7 +168,7 @@ jobs:
 
   windows-steam:
     name: Win32 (Steamworks)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Change GitHub Actions Runner from windows-latest to windows-2022, so Windows binaries can be compiled by GitHub CI again.